### PR TITLE
Referencing Polymer 2 / ES6 static properties

### DIFF
--- a/resettable-properties-behavior.html
+++ b/resettable-properties-behavior.html
@@ -34,8 +34,9 @@ data: {
 **/
   ResettablePropertiesBehavior = {
     _resetProperties: function(group) {
-      for (var propertyName in this.properties) {
-        var property = this.properties[propertyName];
+      var properties = this.constructor && this.constructor.properties ? this.constructor.properties : this.properties;
+      for (var propertyName in properties) {
+        var property = properties[propertyName];
         if (property.resettable) {
           if (!group || (property.resetGroups && property.resetGroups.indexOf(group) > -1)) {
             this.set(propertyName, property.value());


### PR DESCRIPTION
If the component is an ES6 class in Polymer 2, the properties are set statically on the class, so that you have to reference the properties with `this.constructor.properties`.