### PR TITLE
TW-1332 - Add context when resetting properties.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "resettable-properties-behavior",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Polymer behavior that lets you easily reset polymer element properties to their default values.",
   "main": "resettable-properties-behavior.html",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resettable-properties-behavior",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "directories": {
     "test": "test"
   },

--- a/resettable-properties-behavior.html
+++ b/resettable-properties-behavior.html
@@ -37,7 +37,7 @@ ResettablePropertiesBehavior = { // eslint-disable-line no-global-assign
     var properties = this.constructor && this.constructor.properties ? this.constructor.properties : this.properties;
     var defaultPropObject = Object.entries(properties).reduce((acc, [key, {value, resettable, resetGroups}]) => {
       if (resettable && (!group || (resetGroups && resetGroups.includes(group)))) {
-        // TW-1332 - value.apply here because in webpack, we don't get any conext (`this`)
+        // TW-1332 - value.apply here because in webpack, we don't get any context (`this`)
         acc[key] = typeof value === 'function' ? value.apply(this) : value;
       }
       return acc;

--- a/resettable-properties-behavior.html
+++ b/resettable-properties-behavior.html
@@ -37,7 +37,8 @@ ResettablePropertiesBehavior = { // eslint-disable-line no-global-assign
     var properties = this.constructor && this.constructor.properties ? this.constructor.properties : this.properties;
     var defaultPropObject = Object.entries(properties).reduce((acc, [key, {value, resettable, resetGroups}]) => {
       if (resettable && (!group || (resetGroups && resetGroups.includes(group)))) {
-        acc[key] = typeof value === 'function' ? value() : value;
+        // TW-1332 - value.apply here because in webpack, we don't get any conext (`this`)
+        acc[key] = typeof value === 'function' ? value.apply(this) : value;
       }
       return acc;
     }, {});


### PR DESCRIPTION
When resetting properties, `this` is not defined when using webpack. This fixes that.

## Changes
- `value()` => `value.apply(this)`

## To-Dos
- [x] Increment version in bower.json & package.json.
