### PR TITLE
Bug Fix: Properties not being reset correctly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
   ],
   plugins: [
     // Enable plugins that are not natively supported by Code Climate. Otherwise results in build errors.
+    'eslint-plugin-bestpractices',
     'eslint-plugin-deprecate',
     'eslint-plugin-sonarjs'
   ],

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "resettable-properties-behavior",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Polymer behavior that lets you easily reset polymer element properties to their default values.",
   "main": "resettable-properties-behavior.html",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resettable-properties-behavior",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "directories": {
     "test": "test"
   },

--- a/resettable-properties-behavior.html
+++ b/resettable-properties-behavior.html
@@ -43,6 +43,8 @@ ResettablePropertiesBehavior = { // eslint-disable-line no-global-assign
       return acc;
     }, {});
 
+    // 2019-12-03 NOTE: We observed inconsistencies with resettable properties, where some property defaults would only be set if we Object.assign'd twice in a row. We even looped through the assignment manually, with the same results. Just going to do it terribly, for now.
+    Object.assign(this, defaultPropObject);
     Object.assign(this, defaultPropObject);
   },
 


### PR DESCRIPTION
We noticed that some properties in `fs-add-person` were not being reset correctly.
In debugging, we discovered that running the Object.assign() twice in a row resulted in what we expected.

Release version 1.0.3.